### PR TITLE
Entry favorite count & more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+Pipfile*

--- a/ozgursozluk/__init__.py
+++ b/ozgursozluk/__init__.py
@@ -1,7 +1,7 @@
 from flask import Flask
 
 
-__version__ = "0.6.3"
+__version__ = "0.7.0"
 __author__ = "beucismis"
 __source__ = "https://github.com/beucismis/ozgursozluk"
 __description__ = "a free and open source alternative ekşi sözlük front-end"

--- a/ozgursozluk/api.py
+++ b/ozgursozluk/api.py
@@ -44,6 +44,7 @@ class EksiSozluk:
                 entry.find("div", class_="content"),
                 entry.find("a", class_="entry-author").text,
                 entry.find("a", class_="entry-date permalink", href=True).text,
+                int(entry.attrs["data-favorite-count"])
             )
 
     def search_topic(self, query: str) -> Topic:
@@ -94,9 +95,10 @@ class EksiSozluk:
             entry.find("div", class_="content"),
             entry.find("a", class_="entry-author").text,
             entry.find("a", class_="entry-date permalink", href=True).text,
+            int(entry.attrs["data-favorite-count"]),
             int(h1.attrs["data-id"]),
             h1.attrs["data-title"],
-            h1.find("a")["href"][1:],
+            h1.find("a")["href"][1:]
         )
 
     def get_author(self, nickname: str) -> Author:

--- a/ozgursozluk/configs.py
+++ b/ozgursozluk/configs.py
@@ -7,12 +7,14 @@ SECRET_KEY: Final = environ.get("OZGURSOZLUK_SECRET_KEY", "Some secret string")
 DEFAULT_THEME: Final = "light"
 DEFAULT_DISPLAY_PINNED_TOPICS: Final = "true"
 DEFAULT_DISPLAY_AUTHOR_NICKNAMES: Final = "false"
+DEFAULT_DISPLAY_ENTRY_FAVORITE_COUNT: Final = "false"
 DEFAULT_EKSI_SOZLUK_BASE_URL: Final = "https://eksisozluk.com"
 
 DEFAULT_COOKIES: Final = {
     "theme": DEFAULT_THEME,
     "display_pinned_topics": DEFAULT_DISPLAY_PINNED_TOPICS,
     "display_author_nicknames": DEFAULT_DISPLAY_AUTHOR_NICKNAMES,
+    "display_entry_favorite_count": DEFAULT_DISPLAY_ENTRY_FAVORITE_COUNT,
     "eksi_sozluk_base_url": DEFAULT_EKSI_SOZLUK_BASE_URL
 }
 

--- a/ozgursozluk/configs.py
+++ b/ozgursozluk/configs.py
@@ -9,6 +9,13 @@ DEFAULT_DISPLAY_PINNED_TOPICS: Final = "true"
 DEFAULT_DISPLAY_AUTHOR_NICKNAMES: Final = "false"
 DEFAULT_EKSI_SOZLUK_BASE_URL: Final = "https://eksisozluk.com"
 
+DEFAULT_COOKIES: Final = {
+    "theme": DEFAULT_THEME,
+    "display_pinned_topics": DEFAULT_DISPLAY_PINNED_TOPICS,
+    "display_author_nicknames": DEFAULT_DISPLAY_AUTHOR_NICKNAMES,
+    "eksi_sozluk_base_url": DEFAULT_EKSI_SOZLUK_BASE_URL
+}
+
 themes: Final = [
    "light",
    "dark",

--- a/ozgursozluk/models.py
+++ b/ozgursozluk/models.py
@@ -9,15 +9,11 @@ class Entry:
     content_html: str
     author: str
     datetime: str
+    favorite_count: int
 
 
 @dataclass
-class EntryTopic:
-    id: int
-    content: str
-    content_html: str
-    author: str
-    datetime: str
+class EntryTopic(Entry):
     topic_id: int
     topic_title: str
     topic_path: str

--- a/ozgursozluk/templates/entry.html
+++ b/ozgursozluk/templates/entry.html
@@ -17,20 +17,8 @@
                 </p>
             </div>
         </div>
-        <div class="entry">
-            {{ entry.content_html|safe }}
-            </br>
-            <div style="text-align: right;">
-                {% if request.cookies.get('display_author_nicknames') == 'true' %}
-                    <small>
-                        <a href="{{ url_for('author', nickname=entry.author) }}">
-                            {{ entry.author }}
-                        </a>
-                    </small>
-                    -
-                {% endif %}
-                <small>{{ entry.datetime }}</small>
-            </div>
-        </div>
+        {% from "entry_macro.html" import render_entry %}
+        {{ render_entry(entry, False) }}
     </div>
 {% endblock %}
+

--- a/ozgursozluk/templates/entry_macro.html
+++ b/ozgursozluk/templates/entry_macro.html
@@ -1,0 +1,31 @@
+{% macro render_entry(entry, clickable_date) %}
+<div class="entry">
+    {{ entry.content_html|safe }}
+    </br>
+    <div style="text-align: right;">
+        {% if request.cookies.get('display_entry_favorite_count') == 'true' %}
+            <small>
+                {{ entry.favorite_count }} favorites
+            </small>
+            -
+        {% endif %}
+        {% if request.cookies.get('display_author_nicknames') == 'true' %}
+            <small>
+                <a href="{{ url_for('author', nickname=entry.author) }}">
+                    {{ entry.author }}
+                </a>
+            </small>
+            -
+        {% endif %}
+        <small>    
+            {% if clickable_date %}
+                <a href="{{ url_for('entry', id=entry.id) }}">
+                    {{ entry.datetime }}
+                </a>
+            {% else %}
+                {{ entry.datetime }}
+            {% endif %}
+        </small>
+    </div>
+</div>
+{% endmacro %}

--- a/ozgursozluk/templates/paginate.html
+++ b/ozgursozluk/templates/paginate.html
@@ -1,5 +1,5 @@
 <div>
-    {% if a %}
+    {% if not a %}
         {% if p > 1 %}
             <a href="{{ url_for('topic', path=topic.path, p=p-1) }}">previous</a>
             {% if p < topic.page_count %}/{% endif %}

--- a/ozgursozluk/templates/settings.html
+++ b/ozgursozluk/templates/settings.html
@@ -41,6 +41,17 @@
                 </select>
             </div>
             <div class="settings-group">
+                display entry favorite count:
+                <select name="display_entry_favorite_count">
+                    {% for status in ['true', 'false'] %}
+                        <option value="{{ status }}"
+                            {% if  default_display_entry_favorite_count == status %}selected{% endif %}>
+                            {{ status }}
+                        </option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="settings-group">
                 ekşi sözlük base url:
                 <select name="eksi_sozluk_base_url">
                     {% for url in eksi_sozluk_base_urls %}

--- a/ozgursozluk/templates/topic.html
+++ b/ozgursozluk/templates/topic.html
@@ -23,25 +23,8 @@
             {% include "paginate.html" %}
         </div>
         {% for entry in topic.entrys %}
-            <div class="entry">
-                {{ entry.content_html|safe }}
-                </br>
-                <div style="text-align: right;">
-                    {% if request.cookies.get('display_author_nicknames') == 'true' %}
-                        <small>
-                            <a href="{{ url_for('author', nickname=entry.author) }}">
-                                {{ entry.author }}
-                            </a>
-                        </small>
-                        -
-                    {% endif %}
-                    <small>
-                        <a href="{{ url_for('entry', id=entry.id) }}">
-                            {{ entry.datetime }}
-                        </a>
-                    </small>
-                </div>
-            </div>
+            {% from "entry_macro.html" import render_entry %}
+            {{ render_entry(entry, True) }}
         {% endfor %}
         <div class="info" style="padding-top: 0;">
             <div></div>

--- a/ozgursozluk/views.py
+++ b/ozgursozluk/views.py
@@ -6,10 +6,8 @@ from ozgursozluk.utils import last_commit, expires
 from ozgursozluk.configs import (
     themes,
     eksi_sozluk_base_urls,
-    DEFAULT_THEME,
-    DEFAULT_DISPLAY_PINNED_TOPICS,
-    DEFAULT_DISPLAY_AUTHOR_NICKNAMES,
-    DEFAULT_EKSI_SOZLUK_BASE_URL,
+    DEFAULT_COOKIES,
+    DEFAULT_EKSI_SOZLUK_BASE_URL
 )
 
 
@@ -103,43 +101,20 @@ def settings():
 
     if request.method == "POST":
         response = redirect(url_for("settings"))
-        response.set_cookie(
-            "theme",
-            request.form["theme"],
-            expires=expires(),
-        )
-        response.set_cookie(
-            "display_pinned_topics",
-            request.form["display_pinned_topics"],
-            expires=expires(),
-        )
-        response.set_cookie(
-            "display_author_nicknames",
-            request.form["display_author_nicknames"],
-            expires=expires(),
-        )
-        response.set_cookie(
-            "eksi_sozluk_base_url",
-            request.form["eksi_sozluk_base_url"],
-            expires=expires(),
-        )
+        for cookie in DEFAULT_COOKIES:
+            response.set_cookie(
+                cookie,
+                request.form[cookie],
+                expires=expires()
+            )
 
         return response
 
     return render_template(
         "settings.html",
-        default_theme=request.cookies.get(
-            "theme", DEFAULT_THEME,
-        ),
-        default_display_pinned_topics=request.cookies.get(
-            "display_pinned_topics", DEFAULT_DISPLAY_PINNED_TOPICS,
-        ),
-        default_display_author_nicknames=request.cookies.get(
-            "display_author_nicknames", DEFAULT_DISPLAY_AUTHOR_NICKNAMES,
-        ),
-        default_eksi_sozluk_base_url=request.cookies.get(
-            "eksi_sozluk_base_url", DEFAULT_EKSI_SOZLUK_BASE_URL,
-        ),
+        # Unpack DEFAULT_COOKIES variable to the template
+        **{f"default_{cookie}": request.cookies.get(cookie, DEFAULT_COOKIES[cookie])
+           for cookie in DEFAULT_COOKIES}
     )
 
 


### PR DESCRIPTION
- Refactored the settings route by moving default cookie key/value pairs to DEFAULT_COOKIES.
- Refactored the entries by unifying entry templates from both "topic.html," and "entry.html" to a macro at "entry_macro.html," thus reducing repetition.
- Added an option to display favorite counts of entries obtained from "data-favorite-count."
- Fixed a bug that causes şükela to deselect when using navigation.
- Other minor stuff.