### PR TITLE
Build and deploy docker image to GitHub CR on every tag

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+.github

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -1,0 +1,35 @@
+name: Deploy Image
+on:
+  push:
+    tags:
+      - '**'
+
+env:
+  IMAGE_NAME: ozgursozluk
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
+
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+
+      - name: Push image
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker tag $IMAGE_NAME $IMAGE_ID:latest
+          docker push $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 FROM python:3.8-alpine
-RUN pip install ozgursozluk
-EXPOSE 80
-CMD python3 -m gunicorn ozgursozluk:app -b 0.0.0.0:80 -w 3
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+COPY . .
+EXPOSE 8000
+CMD python -m gunicorn ozgursozluk:app -b 0.0.0.0:8000 -w 3

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ COPY requirements.txt .
 RUN pip install -r requirements.txt
 COPY . .
 EXPOSE 8000
-CMD python -m gunicorn ozgursozluk:app -b 0.0.0.0:8000 -w 3
+CMD python -m gunicorn -b 0.0.0.0:8000 -w $(nproc) ozgursozluk:app

--- a/ozgursozluk/templates/settings.html
+++ b/ozgursozluk/templates/settings.html
@@ -72,9 +72,6 @@
             also this website does not have an official affiliation with <i>eksisozluk.com</i>.
             </br></br></br>
             version {{ version }}
-			-
-            last commit:
-            <a href="{{ source_code }}/commit/{{ last_commit }}" target="_blank">{{ last_commit[:8] }}</a>
             -
             made with <3 on the <a href="{{ url_for('topic', path='thinkpad-t61--1883047') }}">t61</a>
         </div>

--- a/ozgursozluk/utils.py
+++ b/ozgursozluk/utils.py
@@ -5,12 +5,3 @@ def expires() -> datetime:
     """One year later."""
 
     return datetime.now() + timedelta(days=365)
-
-
-def last_commit() -> str:
-    """Return the last commit hash."""
-
-    with open(".git/refs/heads/main") as file:
-        hash = file.read()
-
-    return hash

--- a/ozgursozluk/views.py
+++ b/ozgursozluk/views.py
@@ -4,12 +4,11 @@ from flask import url_for, redirect, request, render_template
 
 import ozgursozluk
 from ozgursozluk.scraper import EksiSozluk
-from ozgursozluk.utils import expires, last_commit
+from ozgursozluk.utils import expires
 from ozgursozluk.configs import THEMES, DEFAULT_COOKIES
 
 
 es = EksiSozluk()
-last_commit = last_commit()
 
 
 @ozgursozluk.app.context_processor
@@ -18,7 +17,6 @@ def global_template_variables():
 
     return dict(
         themes=THEMES,
-        last_commit=last_commit,
         version=ozgursozluk.__version__,
         source_code=ozgursozluk.__source_code__,
         description=ozgursozluk.__description__,


### PR DESCRIPTION
This patch adds a workflow to build and release docker image automatically to GitHub Container Registry every time when you push a tag.